### PR TITLE
Proposed patches to allow building "small model" .exe programs

### DIFF
--- a/libgloss/ia16/Makefile.in
+++ b/libgloss/ia16/Makefile.in
@@ -55,14 +55,31 @@ ELKS_SCRIPTS	= elks-separate.ld elks-combined.ld
 ELKS_BSP	= libelks.a
 ELKS_CRT0	= crt0.o
 
-OBJS		= dos-chdir.o dos-close.o dos-fstat.o dos-getcwd.o \
+DOS_TINY_OBJS	= dos-chdir.o dos-close.o dos-fstat.o dos-getcwd.o \
 		dos-isatty.o dos-lseek.o dos-mkdir.o dos-open.o dos-read.o \
 		dos-rename.o dos-rmdir.o dos-sbrk.o dos-unlink.o dos-write.o
-CFLAGS		= -g -Os
-ASFLAGS		= --gdwarf2
-SCRIPTS		= dos-com.ld
-BSP		= libdos-com.a
-CRT0		= dos-com-crt0.o
+DOS_TINY_CFLAGS	= -mseparate-code-segment -g -Os
+DOS_TINY_ASFLAGS =
+DOS_TINY_SCRIPTS = dos-com.ld
+DOS_TINY_BSP	= libdos-com.a
+DOS_TINY_CRT0	= dos-com-crt0.o
+
+DOS_SMALL_OBJS	= $(DOS_TINY_OBJS)
+DOS_SMALL_CFLAGS = $(DOS_TINY_CFLAGS)
+DOS_SMALL_ASFLAGS = $(DOS_TINY_ASFLAGS)
+DOS_SMALL_SCRIPTS = dos-exe-small.ld
+DOS_SMALL_BSP	= libdos-exe-small.a
+DOS_SMALL_CRT0	= dos-exe-small-crt0.o
+
+ALL_SCRIPTS	= $(ELKS_SCRIPTS) $(DOS_TINY_SCRIPTS) $(DOS_SMALL_SCRIPTS)
+ALL_BSP		= $(ELKS_BSP) $(DOS_TINY_BSP) $(DOS_SMALL_BSP)
+
+OBJS		= $(DOS_TINY_OBJS)
+CFLAGS		= $(DOS_TINY_CFLAGS)
+ASFLAGS		= $(DOS_TINY_ASFLAGS)
+SCRIPTS		= $(DOS_TINY_SCRIPTS)
+BSP		= $(DOS_TINY_BSP)
+CRT0		= $(DOS_TINY_CRT0)
 
 # Host specific makefile fragment comes in here.
 @host_makefile_frag@
@@ -70,7 +87,8 @@ CRT0		= dos-com-crt0.o
 # Need to augment the definition from host_makefile_frag above.
 INCLUDES += -I$(srcdir) -I. -I$(srcdir)/.. -I../libnosys
 
-INSTALL_FILES = ${BSP} ${CRT0}
+INSTALL_FILES = ${DOS_TINY_BSP} ${DOS_TINY_CRT0} \
+  ${DOS_SMALL_BSP} ${DOS_SMALL_CRT0}
 ifneq (,$(findstring elks,$(target)))
 INSTALL_FILES += ${ELKS_BSP} ${ELKS_CRT0}
 endif
@@ -85,7 +103,8 @@ all: ${ELKS_CRT0} ${ELKS_BSP} libnosys.a
 endif
 
 ifneq (,$(findstring elf,$(target)))
-all: ${CRT0} ${BSP} libnosys.a
+all: ${DOS_TINY_CRT0} ${DOS_TINY_BSP} ${DOS_SMALL_CRT0} ${DOS_SMALL_BSP} \
+  libnosys.a
 endif
 #
 # Here's where we build the board support packages for each target.
@@ -105,10 +124,14 @@ $(objroot)/newlib/%: %
 	cp -p $^ $@
 
 # This rule, being more specific, overrides the pattern rule above.
-$(objroot)/newlib/$(BSP):
-	ln -s ../libgloss/ia16/$(BSP) $(objroot)/newlib
-$(objroot)/newlib/$(CRT0):
-	ln -s ../libgloss/ia16/$(CRT0) $(objroot)/newlib
+$(objroot)/newlib/$(DOS_TINY_BSP):
+	ln -s ../libgloss/ia16/$(DOS_TINY_BSP) $(objroot)/newlib
+$(objroot)/newlib/$(DOS_TINY_CRT0):
+	ln -s ../libgloss/ia16/$(DOS_TINY_CRT0) $(objroot)/newlib
+$(objroot)/newlib/$(DOS_SMALL_BSP):
+	ln -s ../libgloss/ia16/$(DOS_SMALL_BSP) $(objroot)/newlib
+$(objroot)/newlib/$(DOS_SMALL_CRT0):
+	ln -s ../libgloss/ia16/$(DOS_SMALL_CRT0) $(objroot)/newlib
 $(objroot)/newlib/$(ELKS_BSP):
 	ln -s ../libgloss/ia16/$(ELKS_BSP) $(objroot)/newlib
 $(objroot)/newlib/$(ELKS_CRT0):
@@ -141,21 +164,33 @@ $(ELKS_SYS_OBJS) : elks-syscalls.c elks-syscalls.h
 $(ELKS_BSP) : $(ELKS_SYS_OBJS) $(ELKS_LIB_OBJS)
 	$(AR) rcs $@ $+
 
+$(DOS_TINY_CRT0) : dos-models-crt0.S
+	$(CC) $(CFLAGS_FOR_TARGET) -DTINY -USMALL \
+	  $(ASFLAGS_FOR_TARGET) $(ASFLAGS) -c $(CFLAGS) $< -o $@
+
+$(DOS_SMALL_CRT0) : dos-models-crt0.S
+	$(CC) $(CFLAGS_FOR_TARGET) -UTINY -DSMALL \
+	  $(ASFLAGS_FOR_TARGET) $(ASFLAGS) -c $(CFLAGS) $< -o $@
+
 # We need a link to libnosys.a in this directory, since this is the
 # directory used when test-compiling for configuration for other parts and
 # when running the testsuite.  By using a symbolic link, it does not
 # matter whether libnosys.a is built yet when the rule is executed.
 libnosys.a:
+	rm -f $@
 	ln -s ../libnosys/libnosys.a
 
-$(BSP) : $(OBJS)
+$(DOS_TINY_BSP) : $(DOS_TINY_OBJS)
+	$(AR) rcs $@ $+
+
+$(DOS_SMALL_BSP) : $(DOS_SMALL_OBJS)
 	$(AR) rcs $@ $+
 
 .c.S:
 	${CC} ${CFLAGS_FOR_TARGET} -c $<
 
 clean mostlyclean:
-	rm -f a.out core *.i *.o *-test *.srec *.dis *.x *.hex $(BSP) 
+	rm -f a.out core *.i *.o *-test *.srec *.dis *.x *.hex $(ALL_BSP)
 
 distclean maintainer-clean realclean: clean
 	rm -f Makefile config.status *~
@@ -165,7 +200,7 @@ install:
 	set -e; for x in ${INSTALL_FILES}; do\
 	  ${INSTALL_DATA} $$x $(DESTDIR)${tooldir}/lib${MULTISUBDIR}/$$x; \
 	done
-	@for script in ${SCRIPTS}; do\
+	@for script in ${ALL_SCRIPTS}; do\
 	  ${INSTALL_DATA} ${srcdir}/$${script} $(DESTDIR)${tooldir}/lib${MULTISUBDIR}/$${script}; \
 	done
 

--- a/libgloss/ia16/configure
+++ b/libgloss/ia16/configure
@@ -271,7 +271,7 @@ PACKAGE_VERSION=
 PACKAGE_STRING=
 PACKAGE_BUGREPORT=
 
-ac_unique_file="dos-com-crt0.S"
+ac_unique_file="dos-models-crt0.S"
 ac_subst_vars='SHELL PATH_SEPARATOR PACKAGE_NAME PACKAGE_TARNAME PACKAGE_VERSION PACKAGE_STRING PACKAGE_BUGREPORT exec_prefix prefix program_transform_name bindir sbindir libexecdir datadir sysconfdir sharedstatedir localstatedir libdir includedir oldincludedir infodir mandir build_alias host_alias target_alias DEFS ECHO_C ECHO_N ECHO_T LIBS build build_cpu build_vendor build_os host host_cpu host_vendor host_os target target_cpu target_vendor target_os INSTALL_PROGRAM INSTALL_SCRIPT INSTALL_DATA CC am__leading_dot DEPDIR am__include am__quote AMDEP_TRUE AMDEP_FALSE AMDEPBACKSLASH CCDEPMODE am__fastdepCC_TRUE am__fastdepCC_FALSE AS AR LD RANLIB ac_ct_RANLIB CCAS CCASFLAGS host_makefile_frag_path LIBOBJS LTLIBOBJS'
 ac_subst_files='host_makefile_frag'
 

--- a/libgloss/ia16/configure.in
+++ b/libgloss/ia16/configure.in
@@ -1,6 +1,6 @@
 dnl Process this file with autoconf to produce a configure script.
 AC_PREREQ(2.59)
-AC_INIT(dos-com-crt0.S)
+AC_INIT(dos-models-crt0.S)
 
 AC_CANONICAL_SYSTEM
 AC_ARG_PROGRAM

--- a/libgloss/ia16/dos-exe-small.ld
+++ b/libgloss/ia16/dos-exe-small.ld
@@ -1,0 +1,122 @@
+/* Linker script for DOS executables with separate data and text segments.
+   Partly derived from elks-separate.ld .  */
+
+OUTPUT_FORMAT(binary)
+ENTRY(_start)
+INPUT(crtbegin.o crtend.o dos-exe-small-crt0.o)
+GROUP(-lc -lgcc -ldos-exe-small -lm)
+
+MEMORY
+  {
+    hdrlma  (r)  : ORIGIN = 0x00000, LENGTH = 32
+    hdrvma  (r)  : ORIGIN = 0x00000, LENGTH = 32
+
+    /* Account for the 32-byte header.  */
+    bseglma (wx) : ORIGIN = 0x00020, LENGTH = 0x20000
+    csegvma (wx) : ORIGIN = 0x00020, LENGTH = 0x10000
+    dsegvma (wx) : ORIGIN = 0x00020, LENGTH = 0x10000
+  }
+
+SECTIONS
+  {
+    /* Fabricate a .exe header here.  Although libbfd does have an
+       "i386msdos" back-end which produces an "MZ" exe header, it cannot do
+       certain things (yet).  In particular, we would like to use the .exe
+       header to point %ss to the separate data segment right at startup.  */
+    .hdr : {
+		/* Signature.  */
+		SHORT (0x5a4d)
+		/* Bytes in last 512-byte page.  */
+		SHORT ((LOADADDR (.data) + SIZEOF (.data)) % 512)
+		/* Total number of 512-byte pages.  */
+		SHORT ((LOADADDR (.data) + SIZEOF (.data) + 511) / 512)
+		/* Relocation entries.  */
+		SHORT (0)
+		/* Header size in paragraphs.  */
+		SHORT (2)
+		/* Minimum extra paragraphs.  */
+		SHORT ((0x10000 - SIZEOF (.data) - ADDR (.data)) / 16)
+		/* Maximum extra paragraphs.  Instead of setting this to
+		   0xffff so that the program hogs up all remaining
+		   conventional memory, just let the program have memory up
+		   to the end of the data segment, and ask for more memory
+		   from DOS if it really needs it.  */
+		SHORT ((0x10000 - SIZEOF (.data) - ADDR (.data)) / 16)
+		/* Initial %ss.  */
+		SHORT (LOADADDR (.data) / 16 - ADDR (.data) / 16
+		    + 0x10000 - ORIGIN (bseglma) / 16)
+		/* Initial %sp.  Let it wrap around from 0.  */
+		SHORT (0)
+		/* Checksum (unused).  */
+		SHORT (0)
+		/* Initial %cs:%ip.  */
+		SHORT (_start)
+		SHORT (LOADADDR (.text) / 16 - ADDR (.text) / 16
+		    + 0x10000 - ORIGIN (bseglma) / 16)
+		/* Relocation table offset.  */
+		SHORT (0x1c)
+		/* Overlay number.  */
+		SHORT (0)
+    } >hdrvma AT>hdrlma
+
+    /* Target text sections.  */
+    .text : {
+		__stext = .;
+		*(.startupA)
+		*(.init)
+		*(.startupB)
+		*(.fini)
+		*(.startupC)
+		*(.text) *(.text.*)
+		__etext = .;
+
+		/* Make the data segment start on a paragraph boundary.  */
+		. = ALIGN (16);
+		__etext_padded = .;
+
+		ASSERT(. <= 0x10000,
+		    "Error: too large for a small-model .exe file.");
+
+	} >csegvma AT >bseglma
+	__ltext = __etext - __stext;
+	__ltext_padded = __etext_padded - __stext;
+
+    /* Target data sections.  */
+    .data : {
+		__sdata = .;
+
+		/* Build lists of constructors and destructors.  */
+		KEEP (*crtbegin*.o(.ctors))
+		KEEP (*(EXCLUDE_FILE (*crtend*.o ) .ctors))
+		KEEP (*(SORT(.ctors.*)))
+		KEEP (*(.ctors))
+
+		KEEP (*crtbegin*.o(.dtors))
+		KEEP (*(EXCLUDE_FILE (*crtend*.o ) .dtors))
+		KEEP (*(SORT(.dtors.*)))
+		KEEP (*(.dtors))
+
+		*(.rodata) *(.rodata.*)
+		*(.data) *(.data.*)
+		*(.gcc_except_table)
+		__edata = .;
+
+    	 	 __sbss = .;
+                *(.bss) *(.bss.*)
+                *(COMMON)
+                __ebss = .;
+
+                /* Minimum address allowed for sbrk() to use.  */
+                __heap_end_minimum = ALIGN(8);
+
+		ASSERT(. <= 0xfff8,
+		    "Error: too large for a small-model .exe file.");
+    	} >dsegvma AT >bseglma
+
+	__ldata = __edata - __sdata;
+	__lbss0 = __ebss - __sbss;
+	__lbss1 = __lbss0 + 1;
+	__lbss = __lbss1 / 2;
+
+    /DISCARD/ : { *(.*) }
+  }

--- a/libgloss/ia16/dos-models-crt0.S
+++ b/libgloss/ia16/dos-models-crt0.S
@@ -1,4 +1,10 @@
-# Startup code for a DOS .com file.
+/* Startup code for a "tiny" model DOS .com file with combined text and data
+   segment, or a "small" model DOS .exe file with one text segment and one
+   separate data segment.  */
+
+#if !defined TINY && !defined SMALL
+#error "no memory model defined -- please use either -DTINY or -DSMALL"
+#endif
 
 	.arch i8086
 	.code16
@@ -6,15 +12,38 @@
 	.section .startupA
 	.global _start
 _start:
+#ifndef TINY
+	pushw	%ss
+	popw	%es
+#endif
 	xorw	%ax, %ax
 	movw	$__sbss, %di
 	movw	$__lbss, %cx
 	cld
 	rep	stosw
+#ifndef TINY
+	pushw	%ds
+	pushw	%ss
+	popw	%ds
+#endif
+
+#ifndef TINY
+/* For the small memory model, we need to copy the command line arguments
+   out to the data segment, rather than modify them in place in DOS's DTA ---
+   since the DTA is outside the data segment.  */
+	.lcomm	.Largv,	128
+/* We currently do not use the PSP segment value after startup, so we can
+   overlap .Lpsp with .Largv.  This may change in the future.  */
+	.set	.Lpsp,	.Largv
+#endif
 
 	.section .startupB
 
 	# Find length of environment + progname
+#ifndef TINY
+	popw	%ds
+	movw	%ds, %ss:.Lpsp
+#endif
 	movw	0x2c,	%es
 	xorw	%di,	%di
 	cld
@@ -42,8 +71,10 @@ _start:
 	rep	movsb
 
 	# Push pointers to environment + progname
+#ifdef TINY
 	pushw	%es
 	popw	%ds
+#endif
 	movw	%sp,	%di
 	pushw	%ax		# envp ends with null pointer
 .Lpush_env_pointers:
@@ -62,7 +93,12 @@ _start:
 	# Parse command tail and push argument pointers
 	xorw	%bx,	%bx	# argc
 	movw	$0x81,	%si
+#ifdef TINY
 	movw	%si,	%di
+#else
+	movw	$.Largv, %di
+	movw	%ss:(.Lpsp-.Largv)(%di), %ds
+#endif
 	movw	$1,	%cx
 
 .Lspace:
@@ -93,6 +129,10 @@ _start:
 	pushw	%bx
 	incw	%cx
 .Lfinish:
+#ifndef TINY
+	pushw	%ss
+	popw	%ds
+#endif
 	movw	%sp,	%si
 	movw	%sp,	%di
 	movw	%dx,	%bx


### PR DESCRIPTION
With these patches, I can now create a "small model" (64 KiB code + 64 KiB data) DOS `.exe` files by passing `-T dos-exe-small.ld` to `ia16-elf-gcc` (along with `-mseparate-code-segment` for good measure).  Building "tiny model" `.com` files (64 KiB combined code and data) should continue to work as before, under this patch.

For the "small model" implementation, I use the same approach as that in `elks-separate.ld`, namely to pretend to the linker that the data sections will be "overlaid" on top of the text sections at runtime.  I am not sure if this trick can be generalized to implement other DOS memory models, such as "medium".